### PR TITLE
feat: added support for prefix `data` for alloy binding functions

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -8,6 +8,8 @@ const path = require('path');
 const XmlDocument = require('xmldoc').XmlDocument;
 
 const RESERVED_EVENT_REGEX =  /^on([A-Z].+)/;
+const RESERVED_BACKBONE_REGEX =  /^data([A-Z].+)/;
+
 const platforms = [ 'android', 'iphone', 'ipad', 'ios', 'windows' ];
 
 function gatherEvents(filename) {
@@ -54,6 +56,8 @@ function findEventHandlers(child, events) {
 
 	for (const attr in child.attr) {
 		if (RESERVED_EVENT_REGEX.test(attr)) {
+			events.add(child.attr[attr]);
+		} else if (RESERVED_BACKBONE_REGEX.test(attr)) {
 			events.add(child.attr[attr]);
 		}
 	}


### PR DESCRIPTION
Should now not give errors or warnings for `dataTransform` `dataCollection` `dataFilter` and `dataFunction` etc.