### PR TITLE
fix: detect event handlers with platform prefix

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -11,6 +11,8 @@ const RESERVED_EVENT_REGEX =  /^on([A-Z].+)/;
 const RESERVED_BACKBONE_REGEX =  /^data([A-Z].+)/;
 
 const platforms = [ 'android', 'iphone', 'ipad', 'ios', 'windows' ];
+// eslint-disable-next-line security/detect-non-literal-regexp
+const PLATFORM_ATTR_REGEX = new RegExp(`^(${platforms.join('|')}):`);
 
 function gatherEvents(filename) {
 	const events = new Set();
@@ -53,11 +55,11 @@ function loopChildren(children, events) {
 }
 
 function findEventHandlers(child, events) {
-
 	for (const attr in child.attr) {
-		if (RESERVED_EVENT_REGEX.test(attr)) {
+		const cleanedAttrName = attr.replace(PLATFORM_ATTR_REGEX, '');
+		if (RESERVED_EVENT_REGEX.test(cleanedAttrName)) {
 			events.add(child.attr[attr]);
-		} else if (RESERVED_BACKBONE_REGEX.test(attr)) {
+		} else if (RESERVED_BACKBONE_REGEX.test(cleanedAttrName)) {
 			events.add(child.attr[attr]);
 		}
 	}

--- a/test/fixtures/testApp/app/views/platform-invalid.xml
+++ b/test/fixtures/testApp/app/views/platform-invalid.xml
@@ -1,0 +1,3 @@
+<Alloy>
+  <Window />
+</Alloy>

--- a/test/fixtures/testApp/app/views/platform-valid.xml
+++ b/test/fixtures/testApp/app/views/platform-valid.xml
@@ -1,0 +1,3 @@
+<Alloy>
+  <Window android:onClose="onClose" />
+</Alloy>

--- a/test/no-unused-vars.js
+++ b/test/no-unused-vars.js
@@ -21,6 +21,11 @@ ruleTester.run('no-unused-vars', rule, {
 			code: 'function doTransform() { }; var x; x=2; if(x) {  }',
 			parserOptions: { 'alloy/no-unused-vars': true },
 			filename: path.join(appFixtureDir, 'app', 'controllers', 'index.js')
+		},
+		{
+			code: 'function onClose() {}',
+			parserOptions: { 'alloy/no-unused-vars': true },
+			filename: path.join(appFixtureDir, 'app', 'controllers', 'platform-valid.js')
 		}
 	],
 	invalid: [
@@ -34,6 +39,12 @@ ruleTester.run('no-unused-vars', rule, {
 			code: 'function foo() { }; var x; x=2; if(x) {  }',
 			parserOptions: { 'alloy/no-unused-vars': true },
 			filename: path.join(appFixtureDir, 'app', 'controllers', 'subdir', 'bar.js'),
+			errors: [ { line: 1, column: 10 } ],
+		},
+		{
+			code: 'function onClose() {}',
+			parserOptions: { 'alloy/no-unused-vars': true },
+			filename: path.join(appFixtureDir, 'app', 'controllers', 'platform-invalid.js'),
 			errors: [ { line: 1, column: 10 } ],
 		}
 	]


### PR DESCRIPTION
Fixes detected of platform scoped event handlers like `android:onOpen="onOpen"`, which would be ignored by this plugin before. 